### PR TITLE
Remove setuptools_scm_git_archive as it's obsolete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,7 @@
 requires = [
     "setuptools",
     "wheel",
-    "setuptools_scm",
-    "setuptools_scm_git_archive",
+    "setuptools_scm>=7.0.0",
     "cython",
 ]
 


### PR DESCRIPTION
From the project [README](https://github.com/Changaco/setuptools_scm_git_archive):

```
This plugin is obsolete. ``setuptools_scm >= 7.0.0`` supports Git archives by itself.
```