### PR TITLE
Link to archive version of angusj clipper pages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ About
 
 Pyclipper is a Cython wrapper exposing public functions and classes of
 the C++ translation of the `Angus Johnson's Clipper library (ver.
-6.4.2) <http://www.angusj.com/delphi/clipper.php>`__.
+6.4.2) <https://web.archive.org/web/20220313012148/http://www.angusj.com/delphi/clipper.php>`__.
 
 Pyclipper releases were tested with Python 2.7 and 3.4 on Linux (Ubuntu
 14.04, x64) and Windows (8.1, x64).
@@ -30,7 +30,7 @@ About Clipper
         algorithm.
 
         \ `Angus Johnson's Clipper
-        library <http://www.angusj.com/delphi/clipper.php>`__\ 
+        library <https://web.archive.org/web/20220313012148/http://www.angusj.com/delphi/clipper.php>`__\ 
 
 Install
 =======
@@ -121,7 +121,7 @@ library.
    ``Pyclipper.Execute`` and ``Pyclipper.Execute2``.
 
 Basic clipping example (based on `Angus Johnson's Clipper
-library <http://www.angusj.com/delphi/clipper.php>`__):
+library <https://web.archive.org/web/20220313012148/http://www.angusj.com/delphi/clipper.php>`__):
 
 .. code:: python
 
@@ -172,7 +172,7 @@ Authors
 =======
 
 -  The Clipper library is written by `Angus
-   Johnson <http://www.angusj.com/delphi/clipper.php>`__,
+   Johnson <https://web.archive.org/web/20220313012148/http://www.angusj.com/delphi/clipper.php>`__,
 -  This wrapper was initially written by `Maxime
    Chalton <https://sites.google.com/site/maxelsbackyard/home/pyclipper>`__,
 -  Adaptions to make it work with version 5 written by `Lukas


### PR DESCRIPTION
Since sometime in the past years, the original clipper pages have been removed from angusj. Use a version provided by archive.org instead.